### PR TITLE
use err(3) instead of errx()

### DIFF
--- a/main.c
+++ b/main.c
@@ -139,9 +139,9 @@ main(int argc, char *argv[])
 		SLIST_INSERT_HEAD(&list, &myr[i], entries);
 
 	if (database_open(db_path, &mydb) == -1)
-		errx(1, "database_open");
+		err(1, "database_open");
 	if (index_open(idx_path, &mydb.index) == -1)
-		errx(1, "index_open");
+		err(1, "index_open");
 
 	if (pledge("stdio", NULL) == -1)
 		err(1, "pledge");


### PR DESCRIPTION
database_open() and index_open() are using syscalls and libc functions.
They will set errno in error cases.  Thus, let the user know this info.
