### PR TITLE
Rename mydb to db

### DIFF
--- a/main.c
+++ b/main.c
@@ -86,7 +86,7 @@ define(struct dc_database *db, struct dc_index_list *l)
 int
 main(int argc, char *argv[])
 {
-	struct dc_database mydb;
+	struct dc_database db;
 	struct dc_index_list list;
 	struct dc_index_entry *myr;
 	char *db_path = NULL, *idx_path = NULL;
@@ -138,15 +138,15 @@ main(int argc, char *argv[])
 	for (i = 0; i < MAX_RESULTS; i++)
 		SLIST_INSERT_HEAD(&list, &myr[i], entries);
 
-	if (database_open(db_path, &mydb) == -1)
+	if (database_open(db_path, &db) == -1)
 		errx(1, "database_open");
-	if (index_open(idx_path, &mydb.index) == -1)
+	if (index_open(idx_path, &db.index) == -1)
 		errx(1, "index_open");
 
 	if (pledge("stdio", NULL) == -1)
 		err(1, "pledge");
 
-	if (!Vflag && index_validate(&mydb.index, mydb.size) == -1)
+	if (!Vflag && index_validate(&db.index, db.size) == -1)
 		errx(1, "index_validate");
 
 	for (i = 0; i < argc; i++) {
@@ -156,11 +156,11 @@ main(int argc, char *argv[])
 			lookup[ch] = tolower(lookup[ch]);
 
 		if (eflag) {
-			if ((r = index_exact_find(lookup, &mydb.index,
+			if ((r = index_exact_find(lookup, &db.index,
 			    &list)) == -1)
 				errx(1, "index_exact_find");
 		} else {
-			if ((r = index_prefix_find(lookup, &mydb.index,
+			if ((r = index_prefix_find(lookup, &db.index,
 			    &list)) == -1)
 				errx(1, "index_prefix_find");
 		}
@@ -170,7 +170,7 @@ main(int argc, char *argv[])
 		if (mflag)
 			match(&list);
 		if (dflag)
-			define(&mydb, &list);
+			define(&db, &list);
 	}
 
 	return EXIT_SUCCESS;


### PR DESCRIPTION
In all other places an instance of struct dc_database is also just called 'db'.
