### PR TITLE
Fix mandoc linter warnings and style

### DIFF
--- a/dict.1
+++ b/dict.1
@@ -68,7 +68,7 @@ By default
 validates the index for correctness before looking up words.
 .El
 .Sh FILES
-.Bl -tag -width "/usr/local/freedict/foo-bar/foo-bar.dict.dzXX" -compact
+.Bl -tag -width Ds
 .It Pa /usr/local/freedict/foo-bar/foo-bar.index
 Index file with words of 'foo' and references to words of 'bar'.
 .It Pa /usr/local/freedict/foo-bar/foo-bar.dict.dz

--- a/dict.1
+++ b/dict.1
@@ -56,7 +56,8 @@ Only lookup index etries that exactly match the given
 .It Fl m
 Match
 .Ar words
-in the index of the dictionary. This option is used by default.
+in the index of the dictionary.
+This option is used by default.
 .It Fl V
 Do not validate the index for correctness before matching words to
 reduce the overhead per

--- a/dict.1
+++ b/dict.1
@@ -66,6 +66,7 @@ invocation.
 By default
 .Nm
 validates the index for correctness before looking up words.
+.El
 .Sh FILES
 .Bl -tag -width "/usr/local/freedict/foo-bar/foo-bar.dict.dzXX" -compact
 .It Pa /usr/local/freedict/foo-bar/foo-bar.index
@@ -75,6 +76,7 @@ Database file containing definitions of 'bar'.
 A
 .Xr gzip 1
 file with an additional random access header.
+.El
 .Sh EXAMPLES
 Match all index entries for the English word 'ham' in the 'eng-fra'
 dictionary using an exact match:


### PR DESCRIPTION
- fix: mandoc: WARNING: new sentence, new line
- fix: mandoc: ERROR: inserting missing end of block: Sh breaks Bl
- fix: text with of FILES block
